### PR TITLE
Use latest python version on RTD

### DIFF
--- a/{{cookiecutter.project_slug}}/.readthedocs.yml
+++ b/{{cookiecutter.project_slug}}/.readthedocs.yml
@@ -5,6 +5,12 @@ formats:
 
 requirements_file: ci/rtd-requirements.txt
 
+# Currently RTD's default image only has 3.5
+# This gets us 3.6 (and hopefully 3.7 in the future)
+# https://docs.readthedocs.io/en/latest/yaml-config.html#build-image
+build:
+  image: latest
+
 python:
   version: 3
   pip_install: True


### PR DESCRIPTION
A lot of people are using f-strings and async generators, and want to
use autodoc. By default RTD uses Python 3.5, which will crash if you
try to combine these. This bumps that to 3.6.