### PR TITLE
Python 3.7 is out!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,14 @@ language: python
 python:
   - 3.5
   - 3.6
-  - 3.7
 sudo: false
 dist: trusty
+
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: required
 
 script:
   - ci/travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - 3.5
   - 3.6
+  - 3.7
 sudo: false
 dist: trusty
 

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -13,7 +13,8 @@
     ],
     "earliest_supported_python": [
         "3.5",
-        "3.6"
+        "3.6",
+        "3.7"
     ],
 
     "_comment": [

--- a/tests/test_stuff.py
+++ b/tests/test_stuff.py
@@ -1,2 +1,14 @@
+import subprocess
+import cookiecutter
+
+# make venv
+# inside the new venv, install test requirements and check pytest <project
+# name> works
+
+# make venv
+# inside the new venv, install ci/rtd-requirements.txt, and check sphinx-build
+# works
+# oh and towncrier too
+
 def test_stuff():
     print("woo")

--- a/{{cookiecutter.project_slug}}/.appveyor.yml
+++ b/{{cookiecutter.project_slug}}/.appveyor.yml
@@ -8,8 +8,12 @@ environment:
     - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python35-x64"
 {%- endif %}
+{%- if cookiecutter.earliest_supported_python <= "3.6" %}
     - PYTHON: "C:\\Python36"
     - PYTHON: "C:\\Python36-x64"
+{%- endif %}
+    - PYTHON: "C:\\Python37"
+    - PYTHON: "C:\\Python37-x64"
 
 build_script:
   - "git --no-pager log -n2"

--- a/{{cookiecutter.project_slug}}/.travis.yml
+++ b/{{cookiecutter.project_slug}}/.travis.yml
@@ -9,14 +9,20 @@ matrix:
       env: CHECK_DOCS=1
     - python: 3.6
       env: CHECK_FORMATTING=1
+{%- if cookiecutter.earliest_supported_python <= "3.5" %}
     # The pypy tests are slow, so list them early
     - python: pypy3.5
+{%- endif %}
     # Uncomment if you want to test on pypy nightly:
     # - language: generic
     #   env: USE_PYPY_NIGHTLY=1
+{%- if cookiecutter.earliest_supported_python <= "3.5" %}
     - python: 3.5.0
     - python: 3.5.2
+{%- endif %}
+{%- if cookiecutter.earliest_supported_python <= "3.6" %}
     - python: 3.6
+{%- endif %}
     # As of 2018-07-05, Travis's 3.7 and 3.8 builds only work if you
     # use dist: xenial AND sudo: required
     # See: https://github.com/python-trio/trio/pull/556#issuecomment-402879391
@@ -26,12 +32,16 @@ matrix:
     - python: 3.8-dev
       dist: xenial
       sudo: required
+{%- if cookiecutter.earliest_supported_python <= "3.5" %}
     - os: osx
       language: generic
       env: MACPYTHON=3.5.4
+{%- endif %}
+{%- if cookiecutter.earliest_supported_python <= "3.6" %}
     - os: osx
       language: generic
       env: MACPYTHON=3.6.6
+{%- endif %}
     - os: osx
       language: generic
       env: MACPYTHON=3.7.0


### PR DESCRIPTION
Add 3.7 to the CI, and to the generated projects, and clean up the
"minimum supported python version" logic a bit.